### PR TITLE
Set Sidebar and header to Fixed position

### DIFF
--- a/www/custom_styles.css
+++ b/www/custom_styles.css
@@ -73,8 +73,25 @@
     }
 }
 
-/*UBERI Logo*/
+/* UBERI Logo */
 .uberi-logo {
     justify-self: center;
+    height: 50px;
     width: 150px;
+}
+
+/* Fix header & sidebar position*/
+.main-sidebar {
+    position: fixed !important;
+}
+
+.main-header {
+    position: fixed !important;
+    width: 100%;
+    z-index: 1030;
+    max-height: 50px;
+}
+
+.content-wrapper {
+    padding-top: 25px;
 }


### PR DESCRIPTION
use "!important" in custom_css to override built in inline styling provided by Shiny.

![image](https://github.com/user-attachments/assets/bb399c2e-281f-448a-9152-7cefc57158c9)
