### PR TITLE
Allow locality desc table to scroll-x on mobile viewports

### DIFF
--- a/ui.R
+++ b/ui.R
@@ -842,7 +842,7 @@ ui <- dashboardPage(
                         width = 9,
                         div(
                             DT::dataTableOutput(outputId = "reef_localities_surveyed_table")
-                        )
+                        ) %>% tagAppendAttributes(class = "locality-dt")
                     )
                 )
             ),

--- a/www/custom_styles.css
+++ b/www/custom_styles.css
@@ -75,14 +75,14 @@
 @media (max-width: 768px) {
     .button-container {
         display: flex;
-        flex-direction: column; 
-        gap: 10px; 
+        flex-direction: column;
+        gap: 10px;
     }
 
     .button-container .bttn,
     .button-container .bttn-simple {
-        width: 100%; 
-        text-align: center; 
+        width: 100%;
+        text-align: center;
     }
 }
 
@@ -209,4 +209,9 @@
 
 .highlight-side-tab>ul>.active>a {
     color: white !important;
+}
+
+/* Localities DT */
+.locality-dt {
+    overflow-x: scroll;
 }


### PR DESCRIPTION
The caption scrolls with it. Not sure if it should be left like that.